### PR TITLE
Parameterized builds

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -345,6 +345,21 @@ func (c *Client) Build(account, repo, branch string) (*Build, error) {
 	return build, nil
 }
 
+// ParameterizedBuild triggers a new parameterized build for the given
+// project on the given branch, Marshaling the struct into json and passing
+// in the post body.
+// Returns the new build information
+func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters interface{}) (*Build, error) {
+	build := &Build{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, buildParameters)
+	if err != nil {
+		return nil, err
+	}
+
+	return build, nil
+}
+
 // RetryBuild triggers a retry of the specified build
 // Returns the new build information
 func (c *Client) RetryBuild(account, repo string, buildNum int) (*Build, error) {

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -478,6 +478,31 @@ func TestClient_Build(t *testing.T) {
 	}
 }
 
+func TestClient_ParameterizedBuild(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/project/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{"param":"foo"}`)
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"build_num": 123}`)
+	})
+
+	params := struct {
+		Param string `json:"param"`
+	}{"foo"}
+
+	build, err := client.ParameterizedBuild("jszwedko", "foo", "master", params)
+	if err != nil {
+		t.Errorf("Client.Build(jszwedko, foo, master) returned error: %v", err)
+	}
+
+	want := &Build{BuildNum: 123}
+	if !reflect.DeepEqual(build, want) {
+		t.Errorf("Client.Build(jszwedko, foo, master) returned %+v, want %+v", build, want)
+	}
+}
+
 func TestClient_RetryBuild(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
### Problem

When triggering a build, optional parameters can be passed to override or add environment variables to that job:

https://circleci.com/docs/parameterized-builds/

Currently the library doesn't support doing this (Unless I completely missed it 😳)

### Solution

I though about modifying the `Build` method to taken an optional (Can be nil) body but it changes the interface that some people may be relying on and as there's currently no versioning in the app could end up breaking peoples apps if they pull down the latest version.

Opted for a separate method `ParameterizedBuild` that essentially has an extra parameter for a struct that's Marshalled into a JSON string and posted to the trigger build endpoint. 