### PR TITLE
add FollowProject and EnableProject

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -200,6 +200,24 @@ func (c *Client) ListProjects() ([]*Project, error) {
 	return projects, nil
 }
 
+// EnableProject enables a project - generates a deploy SSH key used to checkout the Github repo.
+// The Github user tied to the Circle API Token must have "admin" access to the repo.
+func (c *Client) EnableProject(account, repo string) error {
+	return c.request("POST", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+}
+
+// FollowProject follows a project
+func (c *Client) FollowProject(account, repo string) (*Project, error) {
+	project := &Project{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/follow", account, repo), project, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return project, nil
+}
+
 // GetProject retrieves a specific project
 // Returns nil of the project is not in the list of watched projects
 func (c *Client) GetProject(account, repo string) (*Project, error) {

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -203,6 +203,38 @@ func TestClient_ListProjects(t *testing.T) {
 	}
 }
 
+func TestClient_EnableProject(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/project/org-name/repo-name/enable", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	err := client.EnableProject("org-name", "repo-name")
+	if err != nil {
+		t.Errorf("Client.EnableProject() returned error: %v", err)
+	}
+}
+
+func TestClient_FollowProject(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/project/org-name/repo-name/follow", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"reponame": "repo-name"}`)
+	})
+
+	project, err := client.FollowProject("org-name", "repo-name")
+	if err != nil {
+		t.Errorf("Client.FollowProject() returned error: %v", err)
+	}
+
+	want := &Project{Reponame: "repo-name"}
+	if !reflect.DeepEqual(project, want) {
+		t.Errorf("Client.FollowProject() returned %+v, want %+v", project, want)
+	}
+}
+
 func TestClient_GetProject(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds support for two more API endpoints.

The calls are for the v1 API, based on: https://github.com/mtchavez/circleci/blob/0970438a82e8cf8c67298d3876bb8ab8fd982a93/lib/circleci/project.rb#L80

Also tested manually.
