### PR TITLE
Made generic request function public

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -106,7 +106,7 @@ type nopCloser struct {
 
 func (n nopCloser) Close() error { return nil }
 
-func (c *Client) request(method, path string, responseStruct interface{}, params url.Values, bodyStruct interface{}) error {
+func (c *Client) Request(method, path string, responseStruct interface{}, params url.Values, bodyStruct interface{}) error {
 	if params == nil {
 		params = url.Values{}
 	}
@@ -180,7 +180,7 @@ func (c *Client) request(method, path string, responseStruct interface{}, params
 func (c *Client) Me() (*User, error) {
 	user := &User{}
 
-	err := c.request("GET", "me", user, nil, nil)
+	err := c.Request("GET", "me", user, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (c *Client) Me() (*User, error) {
 func (c *Client) ListProjects() ([]*Project, error) {
 	projects := []*Project{}
 
-	err := c.request("GET", "projects", &projects, nil, nil)
+	err := c.Request("GET", "projects", &projects, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -203,19 +203,19 @@ func (c *Client) ListProjects() ([]*Project, error) {
 // EnableProject enables a project - generates a deploy SSH key used to checkout the Github repo.
 // The Github user tied to the Circle API Token must have "admin" access to the repo.
 func (c *Client) EnableProject(account, repo string) error {
-	return c.request("POST", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+	return c.Request("POST", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
 }
 
 // DisableProject disables a project
 func (c *Client) DisableProject(account, repo string) error {
-	return c.request("DELETE", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+	return c.Request("DELETE", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
 }
 
 // FollowProject follows a project
 func (c *Client) FollowProject(account, repo string) (*Project, error) {
 	project := &Project{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/follow", account, repo), project, nil, nil)
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/follow", account, repo), project, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (c *Client) recentBuilds(path string, params url.Values, limit, offset int)
 		params.Set("limit", strconv.Itoa(l))
 		params.Set("offset", strconv.Itoa(offset))
 
-		err := c.request("GET", path, &builds, params, nil)
+		err := c.Request("GET", path, &builds, params, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +306,7 @@ func (c *Client) ListRecentBuildsForProject(account, repo, branch, status string
 func (c *Client) GetBuild(account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request("GET", fmt.Sprintf("project/%s/%s/%d", account, repo, buildNum), build, nil, nil)
+	err := c.Request("GET", fmt.Sprintf("project/%s/%s/%d", account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (c *Client) GetBuild(account, repo string, buildNum int) (*Build, error) {
 func (c *Client) ListBuildArtifacts(account, repo string, buildNum int) ([]*Artifact, error) {
 	artifacts := []*Artifact{}
 
-	err := c.request("GET", fmt.Sprintf("project/%s/%s/%d/artifacts", account, repo, buildNum), &artifacts, nil, nil)
+	err := c.Request("GET", fmt.Sprintf("project/%s/%s/%d/artifacts", account, repo, buildNum), &artifacts, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func (c *Client) ListTestMetadata(account, repo string, buildNum int) ([]*TestMe
 		Tests []*TestMetadata `json:"tests"`
 	}{}
 
-	err := c.request("GET", fmt.Sprintf("project/%s/%s/%d/tests", account, repo, buildNum), &metadata, nil, nil)
+	err := c.Request("GET", fmt.Sprintf("project/%s/%s/%d/tests", account, repo, buildNum), &metadata, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +347,7 @@ func (c *Client) ListTestMetadata(account, repo string, buildNum int) ([]*TestMe
 func (c *Client) AddSSHUser(account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/%d/ssh-users", account, repo, buildNum), build, nil, nil)
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/%d/ssh-users", account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (c *Client) AddSSHUser(account, repo string, buildNum int) (*Build, error) 
 func (c *Client) Build(account, repo, branch string) (*Build, error) {
 	build := &Build{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, nil)
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (c *Client) Build(account, repo, branch string) (*Build, error) {
 func (c *Client) RetryBuild(account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/%d/retry", account, repo, buildNum), build, nil, nil)
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/%d/retry", account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +386,7 @@ func (c *Client) RetryBuild(account, repo string, buildNum int) (*Build, error) 
 func (c *Client) CancelBuild(account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/%d/cancel", account, repo, buildNum), build, nil, nil)
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/%d/cancel", account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (c *Client) ClearCache(account, repo string) (string, error) {
 		Status string `json:"status"`
 	}{}
 
-	err := c.request("DELETE", fmt.Sprintf("project/%s/%s/build-cache", account, repo), status, nil, nil)
+	err := c.Request("DELETE", fmt.Sprintf("project/%s/%s/build-cache", account, repo), status, nil, nil)
 	if err != nil {
 		return "", err
 	}
@@ -414,7 +414,7 @@ func (c *Client) ClearCache(account, repo string) (string, error) {
 func (c *Client) AddEnvVar(account, repo, name, value string) (*EnvVar, error) {
 	envVar := &EnvVar{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/envvar", account, repo), envVar, nil, &EnvVar{Name: name, Value: value})
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/envvar", account, repo), envVar, nil, &EnvVar{Name: name, Value: value})
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +427,7 @@ func (c *Client) AddEnvVar(account, repo, name, value string) (*EnvVar, error) {
 func (c *Client) ListEnvVars(account, repo string) ([]EnvVar, error) {
 	envVar := []EnvVar{}
 
-	err := c.request("GET", fmt.Sprintf("project/%s/%s/envvar", account, repo), &envVar, nil, nil)
+	err := c.Request("GET", fmt.Sprintf("project/%s/%s/envvar", account, repo), &envVar, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +437,7 @@ func (c *Client) ListEnvVars(account, repo string) ([]EnvVar, error) {
 
 // DeleteEnvVar deletes the specified environment variable from the project
 func (c *Client) DeleteEnvVar(account, repo, name string) error {
-	return c.request("DELETE", fmt.Sprintf("project/%s/%s/envvar/%s", account, repo, name), nil, nil, nil)
+	return c.Request("DELETE", fmt.Sprintf("project/%s/%s/envvar/%s", account, repo, name), nil, nil, nil)
 }
 
 // AddSSHKey adds a new SSH key to the project
@@ -446,7 +446,7 @@ func (c *Client) AddSSHKey(account, repo, hostname, privateKey string) error {
 		Hostname   string `json:"hostname"`
 		PrivateKey string `json:"private_key"`
 	}{hostname, privateKey}
-	return c.request("POST", fmt.Sprintf("project/%s/%s/ssh-key", account, repo), nil, nil, key)
+	return c.Request("POST", fmt.Sprintf("project/%s/%s/ssh-key", account, repo), nil, nil, key)
 }
 
 // GetActionOutputs fetches the output for the given action
@@ -483,7 +483,7 @@ func (c *Client) GetActionOutputs(a *Action) ([]*Output, error) {
 func (c *Client) ListCheckoutKeys(account, repo string) ([]*CheckoutKey, error) {
 	checkoutKeys := []*CheckoutKey{}
 
-	err := c.request("GET", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), &checkoutKeys, nil, nil)
+	err := c.Request("GET", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), &checkoutKeys, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +502,7 @@ func (c *Client) CreateCheckoutKey(account, repo, keyType string) (*CheckoutKey,
 		KeyType string `json:"type"`
 	}{KeyType: keyType}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), checkoutKey, nil, body)
+	err := c.Request("POST", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), checkoutKey, nil, body)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (c *Client) CreateCheckoutKey(account, repo, keyType string) (*CheckoutKey,
 func (c *Client) GetCheckoutKey(account, repo, fingerprint string) (*CheckoutKey, error) {
 	checkoutKey := &CheckoutKey{}
 
-	err := c.request("GET", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), &checkoutKey, nil, nil)
+	err := c.Request("GET", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), &checkoutKey, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +524,7 @@ func (c *Client) GetCheckoutKey(account, repo, fingerprint string) (*CheckoutKey
 
 // DeleteCheckoutKey fetches the checkout key for the given project by fingerprint
 func (c *Client) DeleteCheckoutKey(account, repo, fingerprint string) error {
-	return c.request("DELETE", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), nil, nil, nil)
+	return c.Request("DELETE", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), nil, nil, nil)
 }
 
 // AddHerokuKey associates a Heroku key with the user's API token to allow
@@ -539,7 +539,7 @@ func (c *Client) AddHerokuKey(key string) error {
 		APIKey string `json:"apikey"`
 	}{APIKey: key}
 
-	return c.request("POST", "/user/heroku-key", nil, nil, body)
+	return c.Request("POST", "/user/heroku-key", nil, nil, body)
 }
 
 // EnvVar represents an environment variable

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -96,9 +96,9 @@ func TestClient_request(t *testing.T) {
 		fmt.Fprint(w, `{"login": "jszwedko"}`)
 	})
 
-	err := client.request("GET", "/me", &User{}, nil, nil)
+	err := client.Request("GET", "/me", &User{}, nil, nil)
 	if err != nil {
-		t.Errorf(`Client.request("GET", "/me", &User{}, nil, nil) errored with %s`, err)
+		t.Errorf(`Client.Request("GET", "/me", &User{}, nil, nil) errored with %s`, err)
 	}
 }
 
@@ -117,9 +117,9 @@ func TestClient_request_withDebug(t *testing.T) {
 		fmt.Fprint(w, `{"login": "jszwedko"}`)
 	})
 
-	err := client.request("GET", "/me", &User{}, nil, nil)
+	err := client.Request("GET", "/me", &User{}, nil, nil)
 	if err != nil {
-		t.Errorf(`Client.request("GET", "/me", &User{}, nil, nil) errored with %s`, err)
+		t.Errorf(`Client.Request("GET", "/me", &User{}, nil, nil) errored with %s`, err)
 	}
 
 	output := buf.String()
@@ -149,7 +149,7 @@ func TestClient_request_unauthenticated(t *testing.T) {
 		fmt.Fprint(w, `{"message": "You must log in first"}`)
 	})
 
-	err := client.request("GET", "/me", &User{}, nil, nil)
+	err := client.Request("GET", "/me", &User{}, nil, nil)
 	testAPIError(t, err, http.StatusUnauthorized, "You must log in first")
 }
 
@@ -161,7 +161,7 @@ func TestClient_request_noErrorMessage(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	err := client.request("GET", "/me", &User{}, nil, nil)
+	err := client.Request("GET", "/me", &User{}, nil, nil)
 	testAPIError(t, err, http.StatusInternalServerError, "")
 }
 


### PR DESCRIPTION
CircleCI has a number of undocumented APIs.  A generic `Request` method is the easiest way to make them all accessible.