### PR TITLE
URL decode branch names returned from projects

### DIFF
--- a/circleci_test.go
+++ b/circleci_test.go
@@ -291,6 +291,28 @@ func TestClient_GetProject_noMatching(t *testing.T) {
 	}
 }
 
+func TestClient_GetProject_urlDecodeBranches(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/projects", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		// using Fprintf instead Fprint becouse `go vet` complains about a possible intention to use a formatted string
+		fmt.Fprintf(w, `[
+			{"username": "jszwedko", "reponame": "bar", "branches": {"apiv1%%2E1": {}}}
+		]`)
+	})
+
+	project, err := client.GetProject("jszwedko", "bar")
+	if err != nil {
+		t.Errorf("Client.GetProject returned error: %v", err)
+	}
+
+	_, ok := project.Branches["apiv1.1"]
+	if !ok {
+		t.Errorf("expected Client.GetProject(%+v, %+v) to return branches containing 'apiv1.1'  got %+v", "jszwedko", "foo", project.Branches)
+	}
+}
+
 func TestClient_recentBuilds_multiPage(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This is unexpected behavior exhibited by the CircleCI API, but has
existed long enough that they are reticent to change it in case people
have come to depend on it.

https://discuss.circleci.com/t/api-returns-url-encoded-branch-names-in-json-response/18524/5

Fixes #17 