### PR TITLE
Fix error when paginating queries

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -110,7 +110,7 @@ func (c *Client) request(method, path string, responseStruct interface{}, params
 	if params == nil {
 		params = url.Values{}
 	}
-	params.Add("circle-token", c.Token)
+	params.Set("circle-token", c.Token)
 
 	u := c.baseURL().ResolveReference(&url.URL{Path: path, RawQuery: params.Encode()})
 


### PR DESCRIPTION
When paginating we were setting up the `circle-token` with multiple
values because `request` did `params.Add("circle-token", ...)` rather
than using `params.Set`.

That results in CircleCI returning a 401.

This fixes the issue.