### PR TITLE
Fixes paramterized build

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -382,7 +382,7 @@ func (c *Client) Build(account, repo, branch string) (*Build, error) {
 // project on the given branch, Marshaling the struct into json and passing
 // in the post body.
 // Returns the new build information
-func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]string) (*Build, error) {
+func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]map[string]string) (*Build, error) {
 	build := &Build{}
 
 	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, buildParameters)

--- a/circleci.go
+++ b/circleci.go
@@ -382,10 +382,14 @@ func (c *Client) Build(account, repo, branch string) (*Build, error) {
 // project on the given branch, Marshaling the struct into json and passing
 // in the post body.
 // Returns the new build information
-func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]map[string]string) (*Build, error) {
+func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]string) (*Build, error) {
 	build := &Build{}
 
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, buildParameters)
+	parameters := struct {
+		BuildParameters map[string]string `json:"build_parameters"`
+	}{BuildParameters: buildParameters}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, parameters)
 	if err != nil {
 		return nil, err
 	}

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -605,10 +605,8 @@ func TestClient_ParameterizedBuild(t *testing.T) {
 		fmt.Fprint(w, `{"build_num": 123}`)
 	})
 
-	params := map[string]map[string]string{
-		"build_parameters": {
-			"param": "foo",
-		},
+	params := map[string]string{
+		"param": "foo",
 	}
 
 	build, err := client.ParameterizedBuild("jszwedko", "foo", "master", params)

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -600,13 +600,15 @@ func TestClient_ParameterizedBuild(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/project/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
-		testBody(t, r, `{"param":"foo"}`)
+		testBody(t, r, `{"build_parameters":{"param":"foo"}}`)
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"build_num": 123}`)
 	})
 
-	params := map[string]string{
-		"param": "foo",
+	params := map[string]map[string]string{
+		"build_parameters": {
+			"param": "foo",
+		},
 	}
 
 	build, err := client.ParameterizedBuild("jszwedko", "foo", "master", params)


### PR DESCRIPTION
The request body for parametrized builds expects the body contents to be in the format:

```json
{  "build_parameters": {
      "parameter_name": "parameter_value",
},
```

But currently just the contents inside the `build_parameters` key is sent, so the values aren't actually used.

I've updated the unit test, and tested this change on a project locally using the `CIRCLE_JOB` parameter to trigger a specific job and with these changes included the correct job is now triggered.