### PR TITLE
Introduce Background field to struct Action

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -923,6 +923,7 @@ type Step struct {
 
 // Action represents an individual action within a build step
 type Action struct {
+	Background         bool       `json:"background"`
 	BashCommand        *string    `json:"bash_command"`
 	Canceled           *bool      `json:"canceled"`
 	Continue           *string    `json:"continue"`


### PR DESCRIPTION
Hi :)

In CircleCI API ver1.1, `action` has `background`.
I wanna use it, so I opened this pull request 👍 

Example response is like below.

```
"actions": [
        {
          "truncated": false,
          "index": 0,
          "parallel": true,
          "failed": null,
          "infrastructure_fail": null,
          "name": "Spin up Environment",
          "bash_command": null,
          "status": "success",
          "timedout": null,
          "continue": null,
          "end_time": "2018-07-04T11:34:19.095Z",
          "type": "test",
          "allocation_id": "<masked>",
          "output_url": "<masked>",
          "start_time": "2018-07-04T11:34:16.705Z",
          "background": false,
          "exit_code": null,
          "insignificant": false,
          "canceled": null,
          "step": 0,
          "run_time_millis": 2390,
          "has_output": true
        },
       
```