### PR TITLE
Fixes #28: `interface {} is string, not *string`

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -707,7 +707,7 @@ type FeatureFlags struct {
 	BuildForkPRs           bool    `json:"build-fork-prs"`
 	AutocancelBuilds       bool    `json:"autocancel-builds"`
 	OSS                    bool    `json:"oss"`
-	MemoryLimit            string `json:"memory-limit"`
+	MemoryLimit            string  `json:"memory-limit"`
 
 	raw map[string]interface{}
 }

--- a/circleci.go
+++ b/circleci.go
@@ -707,7 +707,7 @@ type FeatureFlags struct {
 	BuildForkPRs           bool    `json:"build-fork-prs"`
 	AutocancelBuilds       bool    `json:"autocancel-builds"`
 	OSS                    bool    `json:"oss"`
-	MemoryLimit            *string `json:"memory-limit"`
+	MemoryLimit            string `json:"memory-limit"`
 
 	raw map[string]interface{}
 }
@@ -757,7 +757,7 @@ func (f *FeatureFlags) UnmarshalJSON(b []byte) error {
 
 	if v, ok := f.raw["memory-limit"]; ok {
 		if v != nil {
-			f.MemoryLimit = v.(*string)
+			f.MemoryLimit = v.(string)
 		}
 	}
 


### PR DESCRIPTION
Fixes #28 