### PR TITLE
Introduce Platform field to Build struct

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -864,6 +864,7 @@ type Build struct {
 	Outcome                 string            `json:"outcome"`
 	Parallel                int               `json:"parallel"`
 	Picard                  *Picard           `json:"picard"`
+	Platform                string            `json:"platform"`
 	Previous                *BuildStatus      `json:"previous"`
 	PreviousSuccessfulBuild *BuildStatus      `json:"previous_successful_build"`
 	QueuedAt                string            `json:"queued_at"`


### PR DESCRIPTION
Hi :)

I introduce a new field, `Platform`, into struct `Build`.
The `Platform` field represents the version of CircleCI execution environment.

Example responses follows 👍 

# Example Responses
## CircleCI 1.0
``` 
{
...truncated...
  "platform": "1.0",
  "outcome": "failed",
  "author_name": "0gajun",
  "queued_at": "2016-04-08T09:11:10.369Z",
  "canceled": false,
}
```

## CircleCI 2.0
```
{
...truncated...
  "platform": "2.0",
  "outcome": "success",
  "author_name": null,
  "node": null,
  "queued_at": "2018-06-27T18:00:07.561Z",
  "canceled": false,
  "author_email": null
}
```