### PR TITLE
Fix casting for nullable feature flags

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -739,7 +739,8 @@ func (f *FeatureFlags) UnmarshalJSON(b []byte) error {
 
 	if v, ok := f.raw["fleet"]; ok {
 		if v != nil {
-			f.Fleet = v.(*string)
+			s := v.(string)
+			f.Fleet = &s
 		}
 	}
 
@@ -757,7 +758,8 @@ func (f *FeatureFlags) UnmarshalJSON(b []byte) error {
 
 	if v, ok := f.raw["memory-limit"]; ok {
 		if v != nil {
-			f.MemoryLimit = v.(*string)
+			s := v.(string)
+			f.MemoryLimit = &s
 		}
 	}
 

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -253,6 +253,36 @@ func TestClient_ListProjects_parseFeatureFlagsRaw(t *testing.T) {
 	}
 }
 
+func TestClient_ListProjects_parseNullableFeatureFlags(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/projects", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+		[{
+			"reponame": "foo",
+			"feature_flags": {
+				"memory-limit": "512MB",
+				"fleet": "something"
+			}
+		}]
+		`)
+	})
+
+	projects, err := client.ListProjects()
+	if err != nil {
+		t.Errorf("Client.ListProjects() returned error: %v", err)
+	}
+
+	if *projects[0].FeatureFlags.Fleet != "something" {
+		t.Errorf("expected Client.ListProjects()[0].Fleet to be 'something', was %+v", projects[0].FeatureFlags.Fleet)
+	}
+
+	if *projects[0].FeatureFlags.MemoryLimit != "512MB" {
+		t.Errorf("expected Client.ListProjects()[0].MemoryLimit to be '512MB', was %+v", projects[0].FeatureFlags.MemoryLimit)
+	}
+}
+
 func TestClient_EnableProject(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Was panicing if a nullable feature flag was present as it attempts to cast as a pointer where the JSON decoder has parsed it as a literal.