### PR TITLE
add more generic buildOpts method

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -365,17 +365,11 @@ func (c *Client) AddSSHUser(account, repo string, buildNum int) (*Build, error) 
 	return build, nil
 }
 
-// Build triggers a new build for the given project on the given branch
+// Build triggers a new build for the given project for the given
+// project on the given branch.
 // Returns the new build information
 func (c *Client) Build(account, repo, branch string) (*Build, error) {
-	build := &Build{}
-
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return build, nil
+	return c.BuildOpts(account, repo, branch, nil)
 }
 
 // ParameterizedBuild triggers a new parameterized build for the given
@@ -383,13 +377,18 @@ func (c *Client) Build(account, repo, branch string) (*Build, error) {
 // in the post body.
 // Returns the new build information
 func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]string) (*Build, error) {
+	opts := map[string]interface{}{"build_parameters": buildParameters}
+	return c.BuildOpts(account, repo, branch, opts)
+}
+
+// BuildOpts triggeres a new build for the givent project on the given
+// branch, Marshaling the struct into json and passing
+// in the post body.
+// Returns the new build information
+func (c *Client) BuildOpts(account, repo, branch string, opts map[string]interface{}) (*Build, error) {
 	build := &Build{}
 
-	parameters := struct {
-		BuildParameters map[string]string `json:"build_parameters"`
-	}{BuildParameters: buildParameters}
-
-	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, parameters)
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -650,6 +650,34 @@ func TestClient_ParameterizedBuild(t *testing.T) {
 	}
 }
 
+func TestClient_BuildOpts(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/project/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{"build_parameters":{"param":"foo"},"revision":"SHA"}`)
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"build_num": 123}`)
+	})
+
+	opts := map[string]interface{}{
+		"build_parameters": map[string]string{
+			"param": "foo",
+		},
+		"revision": "SHA",
+	}
+
+	build, err := client.BuildOpts("jszwedko", "foo", "master", opts)
+	if err != nil {
+		t.Errorf("Client.Build(jszwedko, foo, master) returned error: %v", err)
+	}
+
+	want := &Build{BuildNum: 123}
+	if !reflect.DeepEqual(build, want) {
+		t.Errorf("Client.Build(jszwedko, foo, master) returned %+v, want %+v", build, want)
+	}
+}
+
 func TestClient_RetryBuild(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
It is possible to add more than `build_parameters` to a build, for example, you can add `revision`

Adding a new method, a bit more generic and keep to old ones to not break the API

I believe it would also solve, at least partially, #26