### PR TITLE
Feature/build by project split

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -398,6 +398,8 @@ func (c *Client) BuildOpts(account, repo, branch string, opts map[string]interfa
 }
 
 // BuildByProject triggers a build by project (this is the only way to trigger a build for project using Circle 2.1)
+// NOTE: this endpoint is only available in the CircleCI API v1.1. in order to call it, you must instantiate the Client
+// object with the following value for BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
 func (c *Client) BuildByProject(vcsType VcsType, account string, repo string, branch string, revision string, tag string) error {
 	if tag != "" && (branch != "" || revision != "") {
 		return errors.New("cannot specify tag parameter alongside branch or revision")

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -678,6 +678,22 @@ func TestClient_BuildOpts(t *testing.T) {
 	}
 }
 
+func TestClient_BuildByProject(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/project/github/jszwedko/foo/build", func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{"branch":"master","revision":"SHA"}`)
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"status": 200, "body": "Build created"}`)
+	})
+
+	err := client.BuildByProject(VcsTypeGithub, "jszwedko", "foo", "master", "SHA", "")
+	if err != nil {
+		t.Errorf("Client.BuildByProject(github, jszwedko, foo, master, SHA) returned error: %v", err)
+	}
+}
+
 func TestClient_RetryBuild(t *testing.T) {
 	setup()
 	defer teardown()

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -678,19 +678,51 @@ func TestClient_BuildOpts(t *testing.T) {
 	}
 }
 
-func TestClient_BuildByProject(t *testing.T) {
+func TestClient_BuildByProjectBranch(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/project/github/jszwedko/foo/build", func(w http.ResponseWriter, r *http.Request) {
-		testBody(t, r, `{"branch":"master","revision":"SHA"}`)
+		testBody(t, r, `{"branch":"master"}`)
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"status": 200, "body": "Build created"}`)
 	})
 
-	err := client.BuildByProject(VcsTypeGithub, "jszwedko", "foo", "master", "SHA", "")
+	err := client.BuildByProjectBranch(VcsTypeGithub, "jszwedko", "foo", "master")
 	if err != nil {
-		t.Errorf("Client.BuildByProject(github, jszwedko, foo, master, SHA) returned error: %v", err)
+		t.Errorf("Client.BuildByProjectBranch(github, jszwedko, foo, master) returned error: %v", err)
+	}
+}
+
+func TestClient_BuildByProjectRevision(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/project/github/jszwedko/foo/build", func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{"revision":"SHA"}`)
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"status": 200, "body": "Build created"}`)
+	})
+
+	err := client.BuildByProjectRevision(VcsTypeGithub, "jszwedko", "foo", "SHA")
+	if err != nil {
+		t.Errorf("Client.BuildByProjectRevision(github, jszwedko, foo, SHA) returned error: %v", err)
+	}
+}
+
+func TestClient_BuildByProjectTag(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/project/github/jszwedko/foo/build", func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{"tag":"v0.0.1"}`)
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"status": 200, "body": "Build created"}`)
+	})
+
+	err := client.BuildByProjectTag(VcsTypeGithub, "jszwedko", "foo", "v0.0.1")
+	if err != nil {
+		t.Errorf("Client.BuildByProjectTag(github, jszwedko, foo, v0.0.1) returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Continues the work starting in #36 by splitting up the method into three methods, one for each parameter.

I could see exposing a generic method for building by any of the references in the future.