### PR TITLE
add generic build project

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -430,6 +430,22 @@ func (c *Client) BuildByProjectTag(vcsType VcsType, account string, repo string,
 	})
 }
 
+// BuildByProject triggers a build by project (this is the only way to trigger a build for project using Circle 2.1)
+// you can set revision and/or tag/branch
+// this is useful if you need to trigger a build from a PR froma fork, in which you need to set the revision and the
+// branch in this format `pull/PR_NUMBER`
+// ie.:
+//  map[string]interface{}{
+// 		"revision": "8afbae7ec63b2b0f2786740d03161dbb08ba55f5",
+//		"branch"  : "pull/1234",
+// 	})
+//
+// NOTE: this endpoint is only available in the CircleCI API v1.1. in order to call it, you must instantiate the Client
+// object with the following value for BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
+func (c *Client) BuildByProject(vcsType VcsType, account string, repo string, opts map[string]interface{}) error {
+	return c.buildProject(vcsType, account, repo, opts)
+}
+
 func (c *Client) buildProject(vcsType VcsType, account string, repo string, opts map[string]interface{}) error {
 	resp := &BuildByProjectResponse{}
 

--- a/circleci.go
+++ b/circleci.go
@@ -298,8 +298,8 @@ func (c *Client) ListRecentBuilds(limit, offset int) ([]*Build, error) {
 // ListRecentBuildsForProject fetches the list of recent builds for the given repository
 // The status and branch parameters are used to further filter results if non-empty
 // If limit is -1, fetches all builds
-func (c *Client) ListRecentBuildsForProject(account, repo, branch, status string, limit, offset int) ([]*Build, error) {
-	path := fmt.Sprintf("project/%s/%s", account, repo)
+func (c *Client) ListRecentBuildsForProject(vcsType VcsType, account, repo, branch, status string, limit, offset int) ([]*Build, error) {
+	path := fmt.Sprintf("project/%s/%s/%s", vcsType, account, repo)
 	if branch != "" {
 		path = fmt.Sprintf("%s/tree/%s", path, branch)
 	}

--- a/circleci.go
+++ b/circleci.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	defaultBaseURL = &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1/"}
+	defaultBaseURL = &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
 	defaultLogger  = log.New(os.Stderr, "", log.LstdFlags)
 )
 

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -726,6 +726,27 @@ func TestClient_BuildByProjectTag(t *testing.T) {
 	}
 }
 
+func TestClient_BuildByProject(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/project/github/jszwedko/foo/build", func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{"branch":"pull/1234","revision":"8afbae7ec63b2b0f2886740d03161dbb08ba55f5"}`)
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"status": 200, "body": "Build created"}`)
+	})
+
+	opts := map[string]interface{}{
+		"revision": "8afbae7ec63b2b0f2886740d03161dbb08ba55f5",
+		"branch":   "pull/1234",
+	}
+
+	err := client.BuildByProject(VcsTypeGithub, "jszwedko", "foo", opts)
+	if err != nil {
+		t.Errorf("Client.BuildByProjectTag(github, jszwedko, foo, opts) returned error: %v", err)
+	}
+}
+
 func TestClient_RetryBuild(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adding a generic `BuildByProject` because if we need to trigger a PR from a Fork we need to set both `revision` and `branch`

thanks for doing this lib :)